### PR TITLE
Auto focus search box when SuperTabs shows.

### DIFF
--- a/supertabs/popup.js
+++ b/supertabs/popup.js
@@ -123,4 +123,5 @@ function dumpNode(tab, query) {
 
 document.addEventListener('DOMContentLoaded', () => {
   dumpTabs();
+  $('#search').focus();
 });


### PR DESCRIPTION
With custom shortcut key to show SuperTabs, I am able to start it in a snap, but I have to click on search box to input keywords.
I think search box can be automatically focused when started so that I no longer need to use mouse to search.